### PR TITLE
parseMatrix now works exclusively with the output of populateMatrixFast.

### DIFF
--- a/main.py
+++ b/main.py
@@ -477,32 +477,6 @@ def populateMatrixFast(file_path, matrix):
 # print(len(matrix[1]))
 
 
-def parseMatrix(file_path):
-    """
-    Parse the output of populateMatrixFast
-    Assumes the 1st row is the index row, the 2nd row is the column row
-    """
-
-    df = pd.read_csv(file_path, header=None)
-
-    index_row = df.iloc[0]
-    column_row = df.iloc[1]
-    df = df[2:]  # df without the first two lines
-
-    column_row.dropna(axis=0, inplace=True)  # drop NaN columns;
-    index_row.dropna(axis=0, inplace=True)  # drop NaN rows;
-
-    # Find the difference in df vs. column_row
-    remove = len(df.columns) - len(column_row)
-    # Cut the last n columns from df
-    df = df.iloc[:, :-remove]
-
-    df.index = index_row
-    df.columns = column_row
-
-    return df
-
-
 def calculateDS(domain_name, phyla, df, phylum_sizes=None):
     """
     Returns a DS (distribution score) of an F/X-group (str) within the
@@ -579,20 +553,7 @@ def calculateDSMatrix(file_path, phyla, phylum_sizes=None):
     Use custom list of phylum_sizes in case MATRIX does not contain all genomes
     """
 
-    with open(file_path, 'r') as file:
-        output = file.readlines()
-
-    # extract genomes_row & domains_row
-    # remove ''s and the last '\n'
-    genomes_row = list(filter(lambda x: (x != ''), output[0].split(',')))[:-1]
-    domains_row = list(filter(lambda x: (x != ''), output[1].split(',')))[:-1]
-
-    # turn lists into dicts for faster lookup
-    genomes_dict = {item: index for index, item in enumerate(genomes_row)}
-    domains_dict = {item: index for index, item in enumerate(domains_row)}
-
-    # remove them from output
-    output = output[2:]
+    domains_dict, genomes_dict, output = parseMatrix(file_path)
 
     domainDS_dict = {}
     for domain in domains_dict:
@@ -606,7 +567,7 @@ def calculateDSMatrix(file_path, phyla, phylum_sizes=None):
             for genome in genomes:
                 if genome in genomes_dict.keys():
                     gen_index = genomes_dict[genome]
-                    if int(output[gen_index].split(',')[dom_index]) > 0:
+                    if int(output[gen_index][dom_index]) > 0:
                         genome_hit += 1
 
             # Does >50% of genomes in this phylum contain the domain?
@@ -691,20 +652,7 @@ def mapFtoXmatrix(file_path, f_to_x, same):
 
     """
 
-    with open(file_path, 'r') as file:
-        output = file.readlines()
-
-    # extract genomes_row & domains_row
-    # remove ''s and the last '\n'
-    genomes_row = list(filter(lambda x: (x != ''), output[0].split(',')))[:-1]
-    domains_row = list(filter(lambda x: (x != ''), output[1].split(',')))[:-1]
-
-    # turn lists into dicts for faster lookup
-    genomes_dict = {item: index for index, item in enumerate(genomes_row)}
-    domains_dict = {item: index for index, item in enumerate(domains_row)}
-
-    # remove them from output
-    output = output[2:]
+    domains_dict, genomes_dict, output = parseMatrix(file_path)
 
     checked = {}
     no_match = []
@@ -721,13 +669,13 @@ def mapFtoXmatrix(file_path, f_to_x, same):
                     xgroup = same[key][0]
                     break  # some domains appear more than once... just take the first one
             else:
-                print(f'no match for {domain}')
+                # print(f'no match for {domain}')
                 no_match.append(domain)
                 continue  # ignore this column
 
         # check that it's not "ambiguous"
         if xgroup != 'a':
-            dom_index = domains_dict[domain][0]
+            dom_index = domains_dict[domain]
 
             # new X-group
             if xgroup not in checked:
@@ -739,7 +687,7 @@ def mapFtoXmatrix(file_path, f_to_x, same):
                                    zip(checked[xgroup], [x[dom_index] for x in output])]
         if xgroup == 'a':
             ambiguous.append(domain)
-            print(f'{domain} is ambiguous')
+            # print(f'{domain} is ambiguous')
 
     # save 'checked' dict as csv
     csv_file_path = "x-group_genome_matrix_archaea2.csv"
@@ -761,6 +709,34 @@ def mapFtoXmatrix(file_path, f_to_x, same):
     print(f'total # ambiguous F-group: {len(ambiguous)}')
 
     return
+
+
+def parseMatrix(file_path):
+    """
+    Parse the output of populateMatrixFast
+    Assumes the 1st row is the index row, the 2nd row is the column row
+
+    Returns domains_dict, genomes_dict, output (list of lists)
+    """
+
+    with open(file_path, 'r') as file:
+        output = file.readlines()
+
+    # extract genomes_row & domains_row
+    # remove ''s and the last '\n'
+    genomes_row = list(filter(lambda x: (x != ''), output[0].split(',')))[:-1]
+    domains_row = list(filter(lambda x: (x != ''), output[1].split(',')))[:-1]
+
+    # turn lists into dicts for faster lookup
+    genomes_dict = {item: index for index, item in enumerate(genomes_row)}
+    domains_dict = {item: index for index, item in enumerate(domains_row)}
+
+    # parse the rest of output into list of lists
+    output = output[2:]
+    output = [list(map(int, filter(None, line.strip().split(',')))) for line in
+              output]
+    return domains_dict, genomes_dict, output
+
 
 """
 Figuring out why DS of Sigma54_activat = 0.9
@@ -905,31 +881,27 @@ calculateDS for all domains:
 # print(DS_archaea['fake domain name'])  # will raise KeyError
 
 
-# # archaea with calculateDSMatrix (DON'T use pandas df)
-# my_phylum_sizes = [768, 696, 172, 543, 32, 577, 1, 112, 92, 24, 176, 82, 58, 5, 16, 16, 14, 13, 6, 9]
-# DS_archaea_dict = calculateDSMatrix('matrix_archaea_fast.csv', phylum_genomes, my_phylum_sizes)
-#
-# # Specify the CSV file path
-# csv_file_path = 'output.csv'
-#
-# # Write the dictionary to a CSV file
-# with open(csv_file_path, 'w', newline='') as csv_file:
-#     csv_writer = csv.writer(csv_file)
-#
-#     # Write the header
-#     csv_writer.writerow(DS_archaea_dict.keys())
-#
-#     # Write the data
-#     csv_writer.writerows(zip(*DS_archaea_dict.values()))
+# archaea with calculateDSMatrix (DON'T use pandas df)
+my_phylum_sizes = [768, 696, 172, 543, 32, 577, 1, 112, 92, 24, 176, 82, 58, 5, 16, 16, 14, 13, 6, 9]
+DS_archaea_dict = calculateDSMatrix('matrix_archaea_fast.csv', phylum_genomes, my_phylum_sizes)
+
+# Specify the CSV file path
+csv_file_path = 'output.csv'
+
+# Write the dictionary to a CSV file
+with open(csv_file_path, 'w', newline='') as csv_file:
+    csv_writer = csv.writer(csv_file)
+
+    # Write the header
+    csv_writer.writerow(DS_archaea_dict.keys())
+
+    # Write the data
+    csv_writer.writerows(zip(*DS_archaea_dict.values()))
 
 
 # bacteria
 # my_phylum_sizes = [get this from matrix]
 # DS_bacteria_dict = {}
-
-# not enough RAM!! Running this forces Python to halt the run:
-# parsed_bac_matrix = parseMatrix('matrix_bacteria_fast.csv')
-# parsed_bac_matrix.to_csv('matrix_bacteria_fast_parsed.csv')
 
 
 
@@ -981,19 +953,19 @@ F –> X-groups
 # Create a dict f_to_x = {domain.f_name: ['X-group']} from ecod.develop279.domains.txt
 # Make sure to record "ambiguous" case of 1 F-group mapping to 2+ X-groups
 
-# with open('data/ecod.develop279.domains.txt', 'r') as file:
-#     output = file.readlines()
-# f_to_x = {}
-# for line in output:
-#     if line[0] == '#':  # skip the first lines
-#         continue
-#     domain = EcodDomain(line)
-#     # new domain (F-group) name
-#     if domain.f_name not in f_to_x:
-#         f_to_x[domain.f_name] = [domain.f_id.split('.', 1)[0]]  # 2004.1.1.140 => 2004
-#     # old domain (F-group) name AND the X-group is different
-#     elif f_to_x[domain.f_name][0] != domain.f_id.split('.', 1)[0]:
-#         f_to_x[domain.f_name] = 'ambiguous'  # updates the value to 'ambiguous'
+with open('data/ecod.develop279.domains.txt', 'r') as file:
+    output = file.readlines()
+f_to_x = {}
+for line in output:
+    if line[0] == '#':  # skip the first lines
+        continue
+    domain = EcodDomain(line)
+    # new domain (F-group) name
+    if domain.f_name not in f_to_x:
+        f_to_x[domain.f_name] = [domain.f_id.split('.', 1)[0]]  # 2004.1.1.140 => 2004
+    # old domain (F-group) name AND the X-group is different
+    elif f_to_x[domain.f_name][0] != domain.f_id.split('.', 1)[0]:
+        f_to_x[domain.f_name] = 'ambiguous'  # updates the value to 'ambiguous'
 
 # print(f_to_x)
 # print(len(f_to_x))  # 12634: ECOD v.279
@@ -1026,55 +998,55 @@ check cases where f_name contains a comma (e.g., DALR_1,tRNA-synt_1d)
 # print(commas)
 
 # save the set
-# commas = {'SecA_PP_bind,SBP_bac_1_C', 'putA_2nd,Pro_dh-DNA_bdg', 'KOG2546,ATP-synt_ab_Xtn', 'GIDA_assoc_1st,FAD_binding_3_1st', 'HD_5,RNAse_Pc_like', '7tm_2,Rubredoxin', 'GF_recep_IV,Recep_L_domain', 'XRCC4_3rd_2,Tropomyosin_2', 'RNAse_Pc_like,GATA', 'NCD3G,ANF_receptor_2nd_1', 'Hormone_recep_1,SBP_bac_1_N_1', 'NNMT_PNMT_TEMT,RNAse_Pc_like', 'BPD_transp_1,malF', 'PRK11000,ABC_tran_1', 'PLN02303_like,Urease_beta', 'Pyr_redox_dim,Pyr_redox_2', 'PYC_OADA_2nd,PYC_OADA_1st,HMGL-like_2', 'Neur_chan_LBD,Neur_chan_memb', 'PHD,BAH_1', 'Reo_sigma1_C,Reo_sigma1_N', 'PLN00104,RNAse_Pc_like', 'TNFRSF11A_2nd,TNFRSF21', 'zf-CCCH_4,PHD3_KDM5A_like', 'lambda-1,zf-C2H2_6', 'PRK15442_1,Beta-lactamase2', 'BolA,RNAse_Pc_like', 'KOG0384_1,Helicase_C', 'Mst1_SARAH,V-set', 'Internalin_N,LRR_8_3', 'SBP_bac_3_1st,SBP_bac_3_2nd', 'Viral_DNA_bp_2nd,Viral_DNA_bp_3rd', 'RNAse_Pc_like,Vinculin_1st', 'VGCC_beta4Aa_N,SH3_1_2', 'PSI_1,Sema_1', 'LbR_YadA-like,KOG0837_1', 'Sad1_UNC,EUF07923', 'Pkinase_Tyr,UBA_AID_AMPKalpha', 'PRK00566_3rd,RNA_pol_Rpb1_5_3rd', 'Gal_mutarotas_2,DUF5110_1,Glyco_hydro_31_N', 'Ank_2,Arm', 'GMC_oxred_C,GMC_oxred_N', 'PAD,PAD_M', 'KOG4642,TPR_11_4', 'DUF2094,RNAse_Pc_like', 'PLAT,RNAse_Pc_like', 'OTCace_N,RNAse_Pc_like', 'Pectate_lyase_3,Glyco_hydro_120', 'DNA_gyraseB,HATPase_c_1', 'tRNA-synt_1c_C_C,tRNA-synt_1c', 'tRNA-synt_1_1st,leuS_2nd', 'Beta-lactamase_1st,Beta-lactamase_2nd_1,RNAse_Pc_like', 'PRK00566_2nd,RNA_pol_Rpb1_5_3rd', 'SAM_Arap1,2,3_like', 'ANAPC4_WD40_9,Sec16_C', 'PSI_2,EUF07736', 'HD,PolyA_pol_RNAbd', 'KOG0196,Ephrin_lbd', 'PRK11000,ABC_tran', 'Ribonuc_red_lgN,ATP-cone_1', 'PPV_E2_N_C,PPV_E2_N_N', 'HypA,zf-C2H2_19', 'LAGLIDADG_1,Spindle_Spc25', 'MDA5_ID,Helicase_C_1', 'Cytochrome_C554,Cytochrom_C552', 'Methyltransf_11_3,RNAse_Pc_like', 'Hpt,Ank_2', 'Ion_trans_3,KOG0837_1', 'UDPGP_C,UDPGP_N', 'PRK15442,Peptidase_S11_1st_1', 'Hydrolase_4,Peptidase_S9_N', 'Aldo_ket_red,RNAse_Pc_like', 'AMP-binding_2nd,AMP-binding_3rd,AMP-binding_C', 'Fe-ADH_2,Fe-ADH_N', 'TPR_15,RNAse_Pc_like', 'Corona_nucleoca_1st,RNAse_Pc_like', 'I-set_9,I-set_13', 'BACK,BTB', 'murQ_2nd,PRK12570', 'RAI1,RNAse_Pc_like', 'LAGLIDADG_3,RNAse_Pc_like', 'Transferrin_2nd,Transferrin_1st', 'Gcd10p_1st,Gcd10p_2nd', 'RNAse_Pc_like,MarR', 'MR_MLE_N,RNAse_Pc_like', 'KOG2181,LIM_C_3', 'KOG0948,rRNA_proc-arch_3rd', 'GLF,Amino_oxidase_1st', 'ADH_zinc_N,ADH_N_2_1', 'Thrombin_light_1,Trypsin', 'Anticodon_1,tRNA-synt_1g', 'DNA_topoisoIV_2nd_1,DNA_topoisoIV_3rd', 'zf-C5HC2,KOG1246_1st', 'CdAMP_rec,RNAse_Pc_like', 'ANATO,A2M_N_2', 'PROCN_C,PROCN_N', 'PNPase,RNase_PH_1', 'Bac_luciferase,RNAse_Pc_like', 'MOSC_N,Phage_lysozyme_2', 'SAS-6_N_1,EUF08200', 'FOLN_like_1,EUF08727', 'DUF3443_like,RNAse_Pc_like', 'C2,KOG1265', 'PSI_3,EUF07736', 'Glyco_hydro_1,RNAse_Pc_like', 'Peptidase_S6_C,Glyco_hydro_120', 'Ribosomal_L19e_N,EUF07990', 'WIYLD,RNAse_Pc_like', 'Inhibitor_I29,RNAse_Pc_like', 'Metallophos_2_1,EUF08528', 'RRM_1,RNAse_Pc_like', 'EUF08255,SelA_N', 'Glycohydro_20b2,Glyco_hydro_20', 'KOG2181_1,LIM_C_3', 'YadA_stalk_1,EUF07855', 'RNAse_Pc_like,Clathrin_H_link', 'Molybdop_Fe4S4,Molybdopterin_2nd', 'KOG2292,RNAse_Pc_like', 'PksD,EUF08630', 'Molybdopterin_2nd,Molybdop_Fe4S4_1', 'DUF592,SIR2_1st', 'ATP-synt_ab,ATP-synt_ab_N', 'DAP3_C,DAP3_N', 'DUF1861,RNAse_Pc_like', 'EUF07844,Rieske_6', 'Peptidase_M18_1st,Peptidase_M20_1st', 'NOB1_Zn_bind,Ribosomal_L33', 'Glyco_hydro_66_1st,RNAse_Pc_like', 'Acetyltransf_10_4,SCP2_2_N', 'KOG2680_like,TIP49_3rd_1', 'Ribonuc_red_lgC,Ribonuc_red_lgN_1', 'KOG0947_3rd,KOG0948', 'DehI,RNAse_Pc_like', 'NUDIX_1,nudC_2nd', 'Adenosine_kin,RNAse_Pc_like', 'SelB-wing_1,SelB-wing_2', 'SBP_bac_1_C,SBP_bac_1_N_2', 'zf-CCHC,PknG_rubred_like', 'Fusion_gly_2,KOG0837_1', 'gyrB_1st_1,gyrB_1st_2', 'HA2_N,DEAD_3', 'Tudor-knot,RNAse_Pc_like', 'PNPase_1,RNase_PH_1', 'Gal_mutarotas_2,Glyco_hydro_31_N', 'E1-E2_ATPase_N,ATPase-IIC_X-K', 'EUF07859,Reo_sigma1_N_1', 'XRCC4_3rd_1,KOG0161_2nd', 'SIR2_2nd_1,SIR2_1st', 'EBP50_C,PDZ', 'Methyltransf_15,Met_10', 'KOG0652_3rd,KOG0652_2nd', 'RNAse_Pc_like,Enoyl_reductase', 'MGS,EUF08629', 'Pkinase_Tyr,RGS', 'PDZ_2,Trypsin_2', 'H2O2_YaaD,MRP-S27', 'Amidohydro_1_N,Amidohydro_1_C_2', 'KOG0275_2nd,zf_topless', 'Amino_oxidase_1st,Pyr_redox_2_2', 'F5_F8_type_C,RNAse_Pc_like', 'PG_binding_1,EUF07947', 'PRK09243,NAPRTase', 'RNAse_Pc_like,DisA_N', 'Amidohydro_3,D-HYD_N', 'KOG1246_1st,JmjC', 'DALR_1,tRNA-synt_1d', 'EUF08400,vigilin_like_KH_like', 'LRR_8_4,F-box-like_3', 'RNAse_Pc_like,OpuAC_1', 'Hemagglutinin_2nd,Hemagglutinin_1st,EUF08590', 'Sigma54_activat,CDC48', 'RNAse_Pc_like,Dimerisation2_like', 'Dimerisation2,RNAse_Pc_like', 'SBP_bac_1_N_1,RNAse_Pc_like', 'Adap_comp_sub_2nd,Adap_comp_sub_1st', 'PYC_OADA_1st,PYC_OADA_2nd_1', 'YciM,PHD_1', 'Fe_hyd_lg_C,Fe_hyd_SSU', 'KOG1155,ANAPC8', 'TPR_19,ANAPC8_1', 'Sigma70_r3,Sigma70_r2_2', 'TPR_19,ANAPC8', 'Asp_C,Asp_N', 'Methyltransf_11_4,Met_10', 'UvrA,ABC_tran', 'GalP_UDP_transf,GalP_UDP_tr_C', 'PA14,RNAse_Pc_like', 'GP41_2nd_1,GP41_like', 'PBP2_iGluR_NMDA_Nr2_like_1st,Lig_chan_5', 'Granulin_1,EUF08737', 'LepB_N,EUF08529', 'Raptor_N,KOG1517,Arm', 'TPK_catalytic,RNAse_Pc_like', 'DALR_2,tRNA-synt_1g', 'AMP-binding_2nd,AMP-binding_3rd', 'Myosin_head,IQ_2', 'PBP_dimer_2,Transpeptidase_2nd', 'PRK05762_1st,DNA_pol_B_exo1_3rd', 'B,Pkinase_Tyr', 'Flu_NP_1st,Flu_NP_2nd', 'ATP-synt_ab,ATP-synt_ab_C', 'Hemagglutinin_2nd,Hemagglutinin_1st_1', 'Lipase_chap,PolyA_pol_RNAbd', 'Calpain_III,RNAse_Pc_like', 'PRK04342_2nd,PRK04342_1st', 'EAL,RNAse_Pc_like', 'DUF4091,Glyco_hydro_123_N', 'tRNA-synt_1f_1st,LysS', 'HSP70_2nd,HSP70_3rd', 'LppC_1st,RNAse_Pc_like', 'GP41_2nd_1,EUF08590', 'KOG1038,DUF4909', 'ITAM_like,SH3_1_1', 'I-set_13,I-set', 'TusA,RNAse_Pc_like', 'NUDIX_1,KOG0648', 'UxuA,RNAse_Pc_like', 'Rieske_cytochrome_bc1,Rieske_6', 'EUF08311,RNAse_Pc_like', 'GntR,Transcrip_reg_1st', 'Flavi_glycoprot,Flavi_glycop_C', 'EF-hand_7_8,RNAse_Pc_like', 'TIG_4,HLH', 'Ribosomal_S13_N,Ribosomal_S15_2', 'Flo11,RNAse_Pc_like', 'zf-MYND,SET', 'KOG0947_3rd,DSHCT', 'GFP,zf-C2H2_4_like', 'Trp_DMAT,RNAse_Pc_like', 'EF-hand_7_8,IQ_1', 'RhbC_1,IucA_IucC', 'DUF1730,EUF08225', 'KOG1038,RPOL_N', 'RNA_pol_Rpb2_6_2nd,Sigma70_r4', 'DNA_pol3_beta,RNAse_Pc_like', 'Ribonuc_red_sm,RNAse_Pc_like', 'RNAse_Pc_like,HRM_1', 'Sortilin_C_1st,Sortilin-Vps10', 'DUF2225,KOG1086', 'Mfa_like_2_C,Mfa_like_2_N', 'Synuclein,SBP_bac_1_N_1', 'B,KOG0837_1', 'Raptor_N,HEAT_2', 'CODH,Prismane_2nd', 'LacAB_rpiB,RNAse_Pc_like', 'PhoD_1,SapB_1', 'STAT_bind_C,STAT_bind_N', 'NAD_binding_2,RNAse_Pc_like', '7tm_1_1,Cytochrom_B562_1', 'Glyoxalase_2_C,Glyoxalase_14', 'GHMP_kinases_N,RNAse_Pc_like', 'Integrin_beta,KOG1226_1st', 'KOG1562,Spermine_synt_N_1', 'Rho_N,Rho_RNA_bind', 'Secretin_N,PRK15339', 'Pterin_bind,RNAse_Pc_like', 'PNPase_KH,RNase_PH_C_2', 'Chlam_vir_2nd,Chlam_vir_3rd', 'Flu_PB2_2nd,Flu_PB2_3rd', 'dUTPase,RNAse_Pc_like', 'Calici_coat_C_N,Calici_coat_C_C', 'ERM,FERM_M', 'Lig_chan,Lig_chan_1', 'SdrD_B,RNAse_Pc_like', 'DALR_1,tRNA-synt_1_1st', 'Terminase_5,EUF08177', 'RNAse_Pc_like,C2_1', 'Amidohydro_1_C_2,PRK09229', 'Thiol_cytolysin,RNAse_Pc_like', 'Molybdop_Fe4S4,arsenite_ox_L', 'Longin,Synaptobrevin', 'RNAse_Pc_like,AhpC-TSA_1', 'Spectrin,EUF08159', 'zf-UDP,Rep_fac-A_C_N', 'OsmC,RNAse_Pc_like', 'RsmF_methylt_CI,EUF07530', 'I-set_4,fn3', 'ANF_receptor_2nd,ANF_receptor_1st', 'DEAD_1,KOG0951_2nd', 'Glyco_hydro_20b,RNAse_Pc_like', 'HAMP,HisKA', 'Sec23_BS,Sec23_trunk', 'PHF5_1,PHF5_2', 'Glyco_hydro_56,hEGF_3', 'LpxD,RNAse_Pc_like', 'Peptidase_S13_1st,Peptidase_S13_2nd', 'Kringle,WSC', 'gyrB_2nd,gyrB_1st_1,gyrB_1st_2', 'SBP_bac_1_N_1,PRK15442_1', 'Sacchrp_dh_C,Sacchrp_dh_NADP', 'Chromo,RNAse_Pc_like', 'Pox_polyA_pol_C,Pox_polyA_pol', 'Gla_like,Gla', 'Reo_sigma1_C,EUF07859,Reo_sigma1_N_1', 'PRORP_N,PRORP_C', 'RNAse_Pc_like,YcgR_like', 'BNR_2,7tm_1_1', 'Complex1_49kDa_1st,NiFeSe_Hases_1st', 'Crystallin,HSP20', 'PUF,Spermine_synth', 'ketoacyl-synt,Docking_1', 'AHSA1,RNAse_Pc_like', 'p450,RNAse_Pc_like', 'KOG1464,PCI_1', 'Fusion_gly_2,KOG0837', 'TNFR_c6_2,TNFRSF5', 'KOG0196,Laminin_EGF', 'Inhibitor_I69,Peptidase_C10', 'HA2_N,HA2_C', 'PP2C,RNAse_Pc_like', 'PYC_OADA_2nd,PYC_OADA_1st', 'Lyase_aromatic_C,Lyase_aromatic_N', 'OmpH,Vinculin_2nd', 'Fer4_7_1,NADH-G_4Fe-4S_3', 'P-II,PGM_PMM_IV', 'zf-C2H2_1,HSP33_C', 'MerR_1,TipAS', 'DUF5110,Glyco_hydro_31_C', 'Glycophorin_A,SSF', 'PQQ_like,Beta-lactamase2', 'ApbA,ApbA_C', 'ChAPs_C,ChAPs_N', 'I-set_15,I-set_11', 'PRK10954,Filamin_1', 'flgG,Flg_bb_rod', 'Raptor_N,Arm', 'UPF0146,RNAse_Pc_like', 'MukE_C,MukE_N', 'AAA_33,ADK_lid', 'Met_10,Methyltransf_11_2', 'hEGF_3,AMA-1_2nd', 'KOG0161_like,XRCC4_3rd_1', 'Anticodon_1,tRNA-synt_1_1st', 'PADR1,PLN03123', 'Pyridox_ox_2,Yop-YscD_ppl_2nd', 'TMAO_torS,EUF08144', 'ThiG,TIM', 'RNAse_Pc_like,Acyl_transf_1_1st', 'GDP_Man_Dehyd_1,RNAse_Pc_like', 'Ank_2,RNAse_Pc_like', 'ADH_zinc_N,ADH_N', '34_2nd,34_1st', 'B,Phage_lysozyme_2', 'LRR_8_4,KOG4308_like', 'PHD_BAZ1A_like_like,PSI', 'PRK09198,NAPRTase', 'Cytochrom_B561,YajC', 'TPP_enzyme_N,RNAse_Pc_like', 'Translin,RNAse_Pc_like', 'murQ_2nd,murQ_1st', 'Torsin,RecA', 'Glyoxalase_17,Glyoxalase_11', 'FKBP_C,RNAse_Pc_like', 'HTH_20_like,Lactamase_B_1', 'ACT_2,RNAse_Pc_like', 'GalA,RNAse_Pc_like', 'T6SS_VipA,VipB_N', 'Caudo_bapla_RBP_1st_1,Caudo_bapla_RBP_1st', 'Sigma54_activat,Vps4_C_C', 'Cytidylate_kin_2,Thymidylate_kin', 'PSI_2,TIG_3', 'Rieske,HcaE', 'EF-hand_7_8,IQ_like', 'Sigma54_activat,KOG0729', 'YfaS_3rd,YfaS_4th', 'RcbX,RNAse_Pc_like', 'KOG4008,Peripla_BP_4_C', 'DnaJ,RNAse_Pc_like', 'ThiF_2,APPBP1_RUB', 'Nucleoporin_C_C,Nucleoporin_C_N', 'LRR_8_4,F-box-like_4', 'CARD,RNAse_Pc_like', 'EF-hand_7_1,TFA2_2nd', 'RNAse_Pc_like,Hsm3_like', 'Methyltransf_11_2,Gcd10p_2nd', 'Beta-lactamase_1st,Beta-lactamase_2nd_1', '2-Hacid_dh,DUF3410', 'Integrin_b_cyt,IRS_1', 'Sec23_BS,zf-Sec23_Sec24', 'PksD,Acyl_transf_1_1st', 'RNAse_Pc_like,Lactamase_B_6_1', 'EUF08675,NAPRTase', 'Beta-prism_lec,RNAse_Pc_like', 'EUF07924,EUF07925', 'IPPT,IPT', 'RNA_pol_Rpb2_7,RNA_pol_Rpb1_5_3rd_1,RNA_pol_Rpb1_1', 'SET_5,zf-MYND', 'DAO_1st,FMO-like_2nd', 'Pentapeptide_4,RNAse_Pc_like', 'Ribosomal_S5_3,Ribosomal_S5_C_1', 'Aminotran_3_C_1,Aminotran_3_N', 'Thrombin_light,Trypsin', 'EUF08456,RNAse_Pc_like', 'LRR_8_3,RHH_6', 'CTP_transf_like_1,Lipoprotein_6', 'KOG4405,GDI_1st', 'Methyltransf_11_1,RNAse_Pc_like', 'TAXi_C,Asp_N', 'zf-C2H2_18,zf-H2C2_2_like', 'HeLo,RNAse_Pc_like', 'TPR_11_6,RNAse_Pc_like', 'Gal_mutarotas_2,Trefoil', 'RNAse_Pc_like,adh_short_C2_1', 'BLM10_mid,CLASP_N_2', 'DUF892,EUF08144', 'tRNA-synt_1g,Anticodon_Ia_Cys_like', 'PRK15442_1,Peptidase_S11_1st_1', 'PRK15442,Beta-lactamase2', 'KOG1226_1st,hEGF_like_1', 'KOG0163_1,Myosin_head_1', 'Dirigent,EUF08472', 'AAA_33,RNA_pol_Rpc34', 'fn3,EUF08472', 'PYC_OADA_2nd,HMGL-like_2', 'KR_1_SDR_x,EUF08195', 'Bunya_RdRp_3rd,EUF08583', 'Alpha_E2_glycop_2nd,Alpha_E2_glycop_3rd', 'DNA_RNApol_7kD,Shisa', 'AMP-binding_1st,AMP-binding_2nd', 'ZF_C2H2,Rep_fac-A_C_N', 'GFP,DUF4414', 'Plexin_cytopl_1st,KOG0837_1', 'zf-C2H2_13,zf-H2C2_2_like', 'Pico_P1A_C,Pico_P1A_N', 'ADK_lid,Cytidylate_kin_2', 'PCI,KOG2581', 'Se-cys_synth_N_like,EUF08255', 'SATase_N,Hexapep_2_1', 'DUF4982,Lectin_C', 'C1-set_3,C2-set_2_1', 'Peptidase_M27,RNAse_Pc_like', 'CDO_I,RNAse_Pc_like', 'BLM10_mid,BLM10_N', 'SH2,RNAse_Pc_like', 'Ank_2,FERM_f0', 'B,GP41_2nd', 'GGDEF,KOG0837_1'}
+commas = {'SecA_PP_bind,SBP_bac_1_C', 'putA_2nd,Pro_dh-DNA_bdg', 'KOG2546,ATP-synt_ab_Xtn', 'GIDA_assoc_1st,FAD_binding_3_1st', 'HD_5,RNAse_Pc_like', '7tm_2,Rubredoxin', 'GF_recep_IV,Recep_L_domain', 'XRCC4_3rd_2,Tropomyosin_2', 'RNAse_Pc_like,GATA', 'NCD3G,ANF_receptor_2nd_1', 'Hormone_recep_1,SBP_bac_1_N_1', 'NNMT_PNMT_TEMT,RNAse_Pc_like', 'BPD_transp_1,malF', 'PRK11000,ABC_tran_1', 'PLN02303_like,Urease_beta', 'Pyr_redox_dim,Pyr_redox_2', 'PYC_OADA_2nd,PYC_OADA_1st,HMGL-like_2', 'Neur_chan_LBD,Neur_chan_memb', 'PHD,BAH_1', 'Reo_sigma1_C,Reo_sigma1_N', 'PLN00104,RNAse_Pc_like', 'TNFRSF11A_2nd,TNFRSF21', 'zf-CCCH_4,PHD3_KDM5A_like', 'lambda-1,zf-C2H2_6', 'PRK15442_1,Beta-lactamase2', 'BolA,RNAse_Pc_like', 'KOG0384_1,Helicase_C', 'Mst1_SARAH,V-set', 'Internalin_N,LRR_8_3', 'SBP_bac_3_1st,SBP_bac_3_2nd', 'Viral_DNA_bp_2nd,Viral_DNA_bp_3rd', 'RNAse_Pc_like,Vinculin_1st', 'VGCC_beta4Aa_N,SH3_1_2', 'PSI_1,Sema_1', 'LbR_YadA-like,KOG0837_1', 'Sad1_UNC,EUF07923', 'Pkinase_Tyr,UBA_AID_AMPKalpha', 'PRK00566_3rd,RNA_pol_Rpb1_5_3rd', 'Gal_mutarotas_2,DUF5110_1,Glyco_hydro_31_N', 'Ank_2,Arm', 'GMC_oxred_C,GMC_oxred_N', 'PAD,PAD_M', 'KOG4642,TPR_11_4', 'DUF2094,RNAse_Pc_like', 'PLAT,RNAse_Pc_like', 'OTCace_N,RNAse_Pc_like', 'Pectate_lyase_3,Glyco_hydro_120', 'DNA_gyraseB,HATPase_c_1', 'tRNA-synt_1c_C_C,tRNA-synt_1c', 'tRNA-synt_1_1st,leuS_2nd', 'Beta-lactamase_1st,Beta-lactamase_2nd_1,RNAse_Pc_like', 'PRK00566_2nd,RNA_pol_Rpb1_5_3rd', 'SAM_Arap1,2,3_like', 'ANAPC4_WD40_9,Sec16_C', 'PSI_2,EUF07736', 'HD,PolyA_pol_RNAbd', 'KOG0196,Ephrin_lbd', 'PRK11000,ABC_tran', 'Ribonuc_red_lgN,ATP-cone_1', 'PPV_E2_N_C,PPV_E2_N_N', 'HypA,zf-C2H2_19', 'LAGLIDADG_1,Spindle_Spc25', 'MDA5_ID,Helicase_C_1', 'Cytochrome_C554,Cytochrom_C552', 'Methyltransf_11_3,RNAse_Pc_like', 'Hpt,Ank_2', 'Ion_trans_3,KOG0837_1', 'UDPGP_C,UDPGP_N', 'PRK15442,Peptidase_S11_1st_1', 'Hydrolase_4,Peptidase_S9_N', 'Aldo_ket_red,RNAse_Pc_like', 'AMP-binding_2nd,AMP-binding_3rd,AMP-binding_C', 'Fe-ADH_2,Fe-ADH_N', 'TPR_15,RNAse_Pc_like', 'Corona_nucleoca_1st,RNAse_Pc_like', 'I-set_9,I-set_13', 'BACK,BTB', 'murQ_2nd,PRK12570', 'RAI1,RNAse_Pc_like', 'LAGLIDADG_3,RNAse_Pc_like', 'Transferrin_2nd,Transferrin_1st', 'Gcd10p_1st,Gcd10p_2nd', 'RNAse_Pc_like,MarR', 'MR_MLE_N,RNAse_Pc_like', 'KOG2181,LIM_C_3', 'KOG0948,rRNA_proc-arch_3rd', 'GLF,Amino_oxidase_1st', 'ADH_zinc_N,ADH_N_2_1', 'Thrombin_light_1,Trypsin', 'Anticodon_1,tRNA-synt_1g', 'DNA_topoisoIV_2nd_1,DNA_topoisoIV_3rd', 'zf-C5HC2,KOG1246_1st', 'CdAMP_rec,RNAse_Pc_like', 'ANATO,A2M_N_2', 'PROCN_C,PROCN_N', 'PNPase,RNase_PH_1', 'Bac_luciferase,RNAse_Pc_like', 'MOSC_N,Phage_lysozyme_2', 'SAS-6_N_1,EUF08200', 'FOLN_like_1,EUF08727', 'DUF3443_like,RNAse_Pc_like', 'C2,KOG1265', 'PSI_3,EUF07736', 'Glyco_hydro_1,RNAse_Pc_like', 'Peptidase_S6_C,Glyco_hydro_120', 'Ribosomal_L19e_N,EUF07990', 'WIYLD,RNAse_Pc_like', 'Inhibitor_I29,RNAse_Pc_like', 'Metallophos_2_1,EUF08528', 'RRM_1,RNAse_Pc_like', 'EUF08255,SelA_N', 'Glycohydro_20b2,Glyco_hydro_20', 'KOG2181_1,LIM_C_3', 'YadA_stalk_1,EUF07855', 'RNAse_Pc_like,Clathrin_H_link', 'Molybdop_Fe4S4,Molybdopterin_2nd', 'KOG2292,RNAse_Pc_like', 'PksD,EUF08630', 'Molybdopterin_2nd,Molybdop_Fe4S4_1', 'DUF592,SIR2_1st', 'ATP-synt_ab,ATP-synt_ab_N', 'DAP3_C,DAP3_N', 'DUF1861,RNAse_Pc_like', 'EUF07844,Rieske_6', 'Peptidase_M18_1st,Peptidase_M20_1st', 'NOB1_Zn_bind,Ribosomal_L33', 'Glyco_hydro_66_1st,RNAse_Pc_like', 'Acetyltransf_10_4,SCP2_2_N', 'KOG2680_like,TIP49_3rd_1', 'Ribonuc_red_lgC,Ribonuc_red_lgN_1', 'KOG0947_3rd,KOG0948', 'DehI,RNAse_Pc_like', 'NUDIX_1,nudC_2nd', 'Adenosine_kin,RNAse_Pc_like', 'SelB-wing_1,SelB-wing_2', 'SBP_bac_1_C,SBP_bac_1_N_2', 'zf-CCHC,PknG_rubred_like', 'Fusion_gly_2,KOG0837_1', 'gyrB_1st_1,gyrB_1st_2', 'HA2_N,DEAD_3', 'Tudor-knot,RNAse_Pc_like', 'PNPase_1,RNase_PH_1', 'Gal_mutarotas_2,Glyco_hydro_31_N', 'E1-E2_ATPase_N,ATPase-IIC_X-K', 'EUF07859,Reo_sigma1_N_1', 'XRCC4_3rd_1,KOG0161_2nd', 'SIR2_2nd_1,SIR2_1st', 'EBP50_C,PDZ', 'Methyltransf_15,Met_10', 'KOG0652_3rd,KOG0652_2nd', 'RNAse_Pc_like,Enoyl_reductase', 'MGS,EUF08629', 'Pkinase_Tyr,RGS', 'PDZ_2,Trypsin_2', 'H2O2_YaaD,MRP-S27', 'Amidohydro_1_N,Amidohydro_1_C_2', 'KOG0275_2nd,zf_topless', 'Amino_oxidase_1st,Pyr_redox_2_2', 'F5_F8_type_C,RNAse_Pc_like', 'PG_binding_1,EUF07947', 'PRK09243,NAPRTase', 'RNAse_Pc_like,DisA_N', 'Amidohydro_3,D-HYD_N', 'KOG1246_1st,JmjC', 'DALR_1,tRNA-synt_1d', 'EUF08400,vigilin_like_KH_like', 'LRR_8_4,F-box-like_3', 'RNAse_Pc_like,OpuAC_1', 'Hemagglutinin_2nd,Hemagglutinin_1st,EUF08590', 'Sigma54_activat,CDC48', 'RNAse_Pc_like,Dimerisation2_like', 'Dimerisation2,RNAse_Pc_like', 'SBP_bac_1_N_1,RNAse_Pc_like', 'Adap_comp_sub_2nd,Adap_comp_sub_1st', 'PYC_OADA_1st,PYC_OADA_2nd_1', 'YciM,PHD_1', 'Fe_hyd_lg_C,Fe_hyd_SSU', 'KOG1155,ANAPC8', 'TPR_19,ANAPC8_1', 'Sigma70_r3,Sigma70_r2_2', 'TPR_19,ANAPC8', 'Asp_C,Asp_N', 'Methyltransf_11_4,Met_10', 'UvrA,ABC_tran', 'GalP_UDP_transf,GalP_UDP_tr_C', 'PA14,RNAse_Pc_like', 'GP41_2nd_1,GP41_like', 'PBP2_iGluR_NMDA_Nr2_like_1st,Lig_chan_5', 'Granulin_1,EUF08737', 'LepB_N,EUF08529', 'Raptor_N,KOG1517,Arm', 'TPK_catalytic,RNAse_Pc_like', 'DALR_2,tRNA-synt_1g', 'AMP-binding_2nd,AMP-binding_3rd', 'Myosin_head,IQ_2', 'PBP_dimer_2,Transpeptidase_2nd', 'PRK05762_1st,DNA_pol_B_exo1_3rd', 'B,Pkinase_Tyr', 'Flu_NP_1st,Flu_NP_2nd', 'ATP-synt_ab,ATP-synt_ab_C', 'Hemagglutinin_2nd,Hemagglutinin_1st_1', 'Lipase_chap,PolyA_pol_RNAbd', 'Calpain_III,RNAse_Pc_like', 'PRK04342_2nd,PRK04342_1st', 'EAL,RNAse_Pc_like', 'DUF4091,Glyco_hydro_123_N', 'tRNA-synt_1f_1st,LysS', 'HSP70_2nd,HSP70_3rd', 'LppC_1st,RNAse_Pc_like', 'GP41_2nd_1,EUF08590', 'KOG1038,DUF4909', 'ITAM_like,SH3_1_1', 'I-set_13,I-set', 'TusA,RNAse_Pc_like', 'NUDIX_1,KOG0648', 'UxuA,RNAse_Pc_like', 'Rieske_cytochrome_bc1,Rieske_6', 'EUF08311,RNAse_Pc_like', 'GntR,Transcrip_reg_1st', 'Flavi_glycoprot,Flavi_glycop_C', 'EF-hand_7_8,RNAse_Pc_like', 'TIG_4,HLH', 'Ribosomal_S13_N,Ribosomal_S15_2', 'Flo11,RNAse_Pc_like', 'zf-MYND,SET', 'KOG0947_3rd,DSHCT', 'GFP,zf-C2H2_4_like', 'Trp_DMAT,RNAse_Pc_like', 'EF-hand_7_8,IQ_1', 'RhbC_1,IucA_IucC', 'DUF1730,EUF08225', 'KOG1038,RPOL_N', 'RNA_pol_Rpb2_6_2nd,Sigma70_r4', 'DNA_pol3_beta,RNAse_Pc_like', 'Ribonuc_red_sm,RNAse_Pc_like', 'RNAse_Pc_like,HRM_1', 'Sortilin_C_1st,Sortilin-Vps10', 'DUF2225,KOG1086', 'Mfa_like_2_C,Mfa_like_2_N', 'Synuclein,SBP_bac_1_N_1', 'B,KOG0837_1', 'Raptor_N,HEAT_2', 'CODH,Prismane_2nd', 'LacAB_rpiB,RNAse_Pc_like', 'PhoD_1,SapB_1', 'STAT_bind_C,STAT_bind_N', 'NAD_binding_2,RNAse_Pc_like', '7tm_1_1,Cytochrom_B562_1', 'Glyoxalase_2_C,Glyoxalase_14', 'GHMP_kinases_N,RNAse_Pc_like', 'Integrin_beta,KOG1226_1st', 'KOG1562,Spermine_synt_N_1', 'Rho_N,Rho_RNA_bind', 'Secretin_N,PRK15339', 'Pterin_bind,RNAse_Pc_like', 'PNPase_KH,RNase_PH_C_2', 'Chlam_vir_2nd,Chlam_vir_3rd', 'Flu_PB2_2nd,Flu_PB2_3rd', 'dUTPase,RNAse_Pc_like', 'Calici_coat_C_N,Calici_coat_C_C', 'ERM,FERM_M', 'Lig_chan,Lig_chan_1', 'SdrD_B,RNAse_Pc_like', 'DALR_1,tRNA-synt_1_1st', 'Terminase_5,EUF08177', 'RNAse_Pc_like,C2_1', 'Amidohydro_1_C_2,PRK09229', 'Thiol_cytolysin,RNAse_Pc_like', 'Molybdop_Fe4S4,arsenite_ox_L', 'Longin,Synaptobrevin', 'RNAse_Pc_like,AhpC-TSA_1', 'Spectrin,EUF08159', 'zf-UDP,Rep_fac-A_C_N', 'OsmC,RNAse_Pc_like', 'RsmF_methylt_CI,EUF07530', 'I-set_4,fn3', 'ANF_receptor_2nd,ANF_receptor_1st', 'DEAD_1,KOG0951_2nd', 'Glyco_hydro_20b,RNAse_Pc_like', 'HAMP,HisKA', 'Sec23_BS,Sec23_trunk', 'PHF5_1,PHF5_2', 'Glyco_hydro_56,hEGF_3', 'LpxD,RNAse_Pc_like', 'Peptidase_S13_1st,Peptidase_S13_2nd', 'Kringle,WSC', 'gyrB_2nd,gyrB_1st_1,gyrB_1st_2', 'SBP_bac_1_N_1,PRK15442_1', 'Sacchrp_dh_C,Sacchrp_dh_NADP', 'Chromo,RNAse_Pc_like', 'Pox_polyA_pol_C,Pox_polyA_pol', 'Gla_like,Gla', 'Reo_sigma1_C,EUF07859,Reo_sigma1_N_1', 'PRORP_N,PRORP_C', 'RNAse_Pc_like,YcgR_like', 'BNR_2,7tm_1_1', 'Complex1_49kDa_1st,NiFeSe_Hases_1st', 'Crystallin,HSP20', 'PUF,Spermine_synth', 'ketoacyl-synt,Docking_1', 'AHSA1,RNAse_Pc_like', 'p450,RNAse_Pc_like', 'KOG1464,PCI_1', 'Fusion_gly_2,KOG0837', 'TNFR_c6_2,TNFRSF5', 'KOG0196,Laminin_EGF', 'Inhibitor_I69,Peptidase_C10', 'HA2_N,HA2_C', 'PP2C,RNAse_Pc_like', 'PYC_OADA_2nd,PYC_OADA_1st', 'Lyase_aromatic_C,Lyase_aromatic_N', 'OmpH,Vinculin_2nd', 'Fer4_7_1,NADH-G_4Fe-4S_3', 'P-II,PGM_PMM_IV', 'zf-C2H2_1,HSP33_C', 'MerR_1,TipAS', 'DUF5110,Glyco_hydro_31_C', 'Glycophorin_A,SSF', 'PQQ_like,Beta-lactamase2', 'ApbA,ApbA_C', 'ChAPs_C,ChAPs_N', 'I-set_15,I-set_11', 'PRK10954,Filamin_1', 'flgG,Flg_bb_rod', 'Raptor_N,Arm', 'UPF0146,RNAse_Pc_like', 'MukE_C,MukE_N', 'AAA_33,ADK_lid', 'Met_10,Methyltransf_11_2', 'hEGF_3,AMA-1_2nd', 'KOG0161_like,XRCC4_3rd_1', 'Anticodon_1,tRNA-synt_1_1st', 'PADR1,PLN03123', 'Pyridox_ox_2,Yop-YscD_ppl_2nd', 'TMAO_torS,EUF08144', 'ThiG,TIM', 'RNAse_Pc_like,Acyl_transf_1_1st', 'GDP_Man_Dehyd_1,RNAse_Pc_like', 'Ank_2,RNAse_Pc_like', 'ADH_zinc_N,ADH_N', '34_2nd,34_1st', 'B,Phage_lysozyme_2', 'LRR_8_4,KOG4308_like', 'PHD_BAZ1A_like_like,PSI', 'PRK09198,NAPRTase', 'Cytochrom_B561,YajC', 'TPP_enzyme_N,RNAse_Pc_like', 'Translin,RNAse_Pc_like', 'murQ_2nd,murQ_1st', 'Torsin,RecA', 'Glyoxalase_17,Glyoxalase_11', 'FKBP_C,RNAse_Pc_like', 'HTH_20_like,Lactamase_B_1', 'ACT_2,RNAse_Pc_like', 'GalA,RNAse_Pc_like', 'T6SS_VipA,VipB_N', 'Caudo_bapla_RBP_1st_1,Caudo_bapla_RBP_1st', 'Sigma54_activat,Vps4_C_C', 'Cytidylate_kin_2,Thymidylate_kin', 'PSI_2,TIG_3', 'Rieske,HcaE', 'EF-hand_7_8,IQ_like', 'Sigma54_activat,KOG0729', 'YfaS_3rd,YfaS_4th', 'RcbX,RNAse_Pc_like', 'KOG4008,Peripla_BP_4_C', 'DnaJ,RNAse_Pc_like', 'ThiF_2,APPBP1_RUB', 'Nucleoporin_C_C,Nucleoporin_C_N', 'LRR_8_4,F-box-like_4', 'CARD,RNAse_Pc_like', 'EF-hand_7_1,TFA2_2nd', 'RNAse_Pc_like,Hsm3_like', 'Methyltransf_11_2,Gcd10p_2nd', 'Beta-lactamase_1st,Beta-lactamase_2nd_1', '2-Hacid_dh,DUF3410', 'Integrin_b_cyt,IRS_1', 'Sec23_BS,zf-Sec23_Sec24', 'PksD,Acyl_transf_1_1st', 'RNAse_Pc_like,Lactamase_B_6_1', 'EUF08675,NAPRTase', 'Beta-prism_lec,RNAse_Pc_like', 'EUF07924,EUF07925', 'IPPT,IPT', 'RNA_pol_Rpb2_7,RNA_pol_Rpb1_5_3rd_1,RNA_pol_Rpb1_1', 'SET_5,zf-MYND', 'DAO_1st,FMO-like_2nd', 'Pentapeptide_4,RNAse_Pc_like', 'Ribosomal_S5_3,Ribosomal_S5_C_1', 'Aminotran_3_C_1,Aminotran_3_N', 'Thrombin_light,Trypsin', 'EUF08456,RNAse_Pc_like', 'LRR_8_3,RHH_6', 'CTP_transf_like_1,Lipoprotein_6', 'KOG4405,GDI_1st', 'Methyltransf_11_1,RNAse_Pc_like', 'TAXi_C,Asp_N', 'zf-C2H2_18,zf-H2C2_2_like', 'HeLo,RNAse_Pc_like', 'TPR_11_6,RNAse_Pc_like', 'Gal_mutarotas_2,Trefoil', 'RNAse_Pc_like,adh_short_C2_1', 'BLM10_mid,CLASP_N_2', 'DUF892,EUF08144', 'tRNA-synt_1g,Anticodon_Ia_Cys_like', 'PRK15442_1,Peptidase_S11_1st_1', 'PRK15442,Beta-lactamase2', 'KOG1226_1st,hEGF_like_1', 'KOG0163_1,Myosin_head_1', 'Dirigent,EUF08472', 'AAA_33,RNA_pol_Rpc34', 'fn3,EUF08472', 'PYC_OADA_2nd,HMGL-like_2', 'KR_1_SDR_x,EUF08195', 'Bunya_RdRp_3rd,EUF08583', 'Alpha_E2_glycop_2nd,Alpha_E2_glycop_3rd', 'DNA_RNApol_7kD,Shisa', 'AMP-binding_1st,AMP-binding_2nd', 'ZF_C2H2,Rep_fac-A_C_N', 'GFP,DUF4414', 'Plexin_cytopl_1st,KOG0837_1', 'zf-C2H2_13,zf-H2C2_2_like', 'Pico_P1A_C,Pico_P1A_N', 'ADK_lid,Cytidylate_kin_2', 'PCI,KOG2581', 'Se-cys_synth_N_like,EUF08255', 'SATase_N,Hexapep_2_1', 'DUF4982,Lectin_C', 'C1-set_3,C2-set_2_1', 'Peptidase_M27,RNAse_Pc_like', 'CDO_I,RNAse_Pc_like', 'BLM10_mid,BLM10_N', 'SH2,RNAse_Pc_like', 'Ank_2,FERM_f0', 'B,GP41_2nd', 'GGDEF,KOG0837_1'}
 
-# # let's split them
-# xpairs = []
-# for comma in commas:
-#     xpair = comma.split(',', 1)
-#     # f_name contains 1 comma
-#     if ',' not in xpair[1]:
-#         xpairs.append(xpair)
-#     # f_name contains 2+ commas
-#     else:
-#         last_two = xpair[1].split(',', 1)
-#         new = [xpair[0], *last_two]  # unlist using *
-#         xpairs.append(new)
+# let's split them
+xpairs = []
+for comma in commas:
+    xpair = comma.split(',', 1)
+    # f_name contains 1 comma
+    if ',' not in xpair[1]:
+        xpairs.append(xpair)
+    # f_name contains 2+ commas
+    else:
+        last_two = xpair[1].split(',', 1)
+        new = [xpair[0], *last_two]  # unlist using *
+        xpairs.append(new)
 # print(xpairs)
 
-# # find their X-group integer code to see if they're the same or not
-# xpairs_int = {}
-# for pair in xpairs:
-#     integers = []
-#     for domain in pair:
-#         # search within f_to_x dictionary
-#         try:
-#             integers.append(f_to_x[domain][0])
-#         # domain name NEVER appears in isolation (e.g., KOG1038)
-#         except:
-#             for key in f_to_x:
-#                 if domain in key:
-#                     integers.append(f_to_x[key][0])
-#                     print(key)
-#                     break  # only need one
-#     # remove anything with 'ambiguous'
-#     if 'a' not in integers:
-#         if len(integers) == 3:
-#             xpairs_int[pair[0] + ',' + pair[1] + ',' + pair[2]] = integers
-#         if len(integers) == 2:
-#             xpairs_int[pair[0] + ',' + pair[1]] = integers
+# find their X-group integer code to see if they're the same or not
+xpairs_int = {}
+for pair in xpairs:
+    integers = []
+    for domain in pair:
+        # search within f_to_x dictionary
+        try:
+            integers.append(f_to_x[domain][0])
+        # domain name NEVER appears in isolation (e.g., KOG1038)
+        except:
+            for key in f_to_x:
+                if domain in key:
+                    integers.append(f_to_x[key][0])
+                    print(key)
+                    break  # only need one
+    # remove anything with 'ambiguous'
+    if 'a' not in integers:
+        if len(integers) == 3:
+            xpairs_int[pair[0] + ',' + pair[1] + ',' + pair[2]] = integers
+        if len(integers) == 2:
+            xpairs_int[pair[0] + ',' + pair[1]] = integers
 # print(xpairs_int)
 # print(len(xpairs_int))  # 313 (436 including pairs with 'a')
-#
-# # create a dictionary of double/triple F_name entries with the SAME X-group
-# same = {}
-# for xpair, domains in xpairs_int.items():
-#     if len(domains) == 2:
-#         if domains[0] == domains[1]:
-#             same[xpair] = domains
-#     if len(domains) == 3:
-#         if domains[0] == domains[1] == domains[2]:
-#             same[xpair] = domains
+
+# create a dictionary of double/triple F_name entries with the SAME X-group
+same = {}
+for xpair, domains in xpairs_int.items():
+    if len(domains) == 2:
+        if domains[0] == domains[1]:
+            same[xpair] = domains
+    if len(domains) == 3:
+        if domains[0] == domains[1] == domains[2]:
+            same[xpair] = domains
 
 # print(len(same))  # 87
 # print(same)
@@ -1092,16 +1064,22 @@ check cases where f_name contains a comma (e.g., DALR_1,tRNA-synt_1d)
 
 
 """
-Finally, let's map FtoX and save a new matrix as csv
+Finally, map FtoX and save a new matrix as csv
 """
 
-# # let's use mapFtoX to create "x-group_genome_matrix_archaea.csv"
+# archaea
+# # use mapFtoX to create "x-group_genome_matrix_archaea.csv"
 # df = pd.read_csv('domain_genome_matrix_archaea.csv', index_col=0)
 #
 # df = mapFtoX(df, f_to_x, same)
 #
 # # Save the DataFrame to a CSV file
 # df.to_csv('x-group_genome_matrix_archaea.csv')
+
+
+# archaea (matrix, no pandas)
+# # use mapFtoXmatrix
+# mapFtoXmatrix('matrix_archaea_fast.csv', f_to_x, same)
 
 
 """


### PR DESCRIPTION
No more dependence on pandas.

calculateDSMatrix & mapFtoXmatrix now uses parseMatrix.